### PR TITLE
LPS-51077 - include fields from parent structure to check uniqueness …

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/META-INF/resources/edit_structure.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/META-INF/resources/edit_structure.jsp
@@ -37,10 +37,20 @@ long parentStructureId = BeanParamUtil.getLong(structure, request, "parentStruct
 
 String parentStructureName = StringPool.BLANK;
 
+String parentFieldsJSONArrayString = StringPool.BLANK;
+
 try {
 	DDMStructure parentStructure = DDMStructureServiceUtil.getStructure(parentStructureId);
 
 	parentStructureName = parentStructure.getName(locale);
+	
+	String parentScript = BeanParamUtil.getString(parentStructure, request, "definition");
+	
+	JSONArray parentFieldsJSONArray = DDMUtil.getDDMFormFieldsJSONArray(parentStructure, parentScript);
+	
+	if (parentFieldsJSONArray != null) {
+		parentFieldsJSONArrayString = parentFieldsJSONArray.toString();
+	}
 }
 catch (NoSuchStructureException nsee) {
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/META-INF/resources/form_builder.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/META-INF/resources/form_builder.jsp
@@ -20,6 +20,7 @@
 String portletResourceNamespace = ParamUtil.getString(request, "portletResourceNamespace");
 String script = ParamUtil.getString(request, "script");
 String fieldsJSONArrayString = ParamUtil.getString(request, "fieldsJSONArrayString");
+String parentFieldsJSONArrayString = ParamUtil.getString(request, "parentFieldsJSONArrayString");
 %>
 
 <%@ include file="/form_builder.jspf" %>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/META-INF/resources/form_builder.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/META-INF/resources/form_builder.jspf
@@ -195,6 +195,10 @@ for (Locale availableLocale : LanguageUtil.getAvailableLocales(themeDisplay.getS
 			<c:if test="<%= Validator.isNotNull(fieldsJSONArrayString) %>">
 				fields: <%= fieldsJSONArrayString %>,
 			</c:if>
+			
+			<c:if test="<%= Validator.isNotNull(parentFieldsJSONArrayString) %>">
+				parentFields: <%= parentFieldsJSONArrayString %>,
+			</c:if>
 
 			portletNamespace: '<portlet:namespace />',
 			portletResourceNamespace: '<%= HtmlUtil.escapeJS(portletResourceNamespace) %>',

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/META-INF/resources/js/main.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/META-INF/resources/js/main.js
@@ -126,7 +126,15 @@ AUI.add(
 					portletNamespace: {
 						value: STR_BLANK
 					},
-
+					
+					parentFields: {
+				        value: [],
+				        setter: '_setParentFields',
+				        validator: function(val) {
+				            return A.Lang.isArray(val) || isArrayList(val);
+				        }
+				    },
+					
 					portletResourceNamespace: {
 						value: STR_BLANK
 					},
@@ -307,6 +315,18 @@ AUI.add(
 						return LiferayFormBuilder.superclass.plotField.apply(instance, arguments);
 					},
 
+					plotFields: function(fields, container) {
+						var instance = this;
+
+						 parentFields = instance.get('parentFields');
+						
+						 A.each(parentFields, function(field) {
+							 LiferayFormBuilder.UNIQUE_FIELD_NAMES_MAP.put(field.get('name'), field);
+				            });
+
+						return LiferayFormBuilder.superclass.plotFields.apply(instance, arguments);
+					},
+					
 					_afterEditingLocaleChange: function(event) {
 						var instance = this;
 
@@ -538,12 +558,23 @@ AUI.add(
 
 					_setFields: function() {
 						var instance = this;
-
+						
 						LiferayFormBuilder.UNIQUE_FIELD_NAMES_MAP.clear();
 
 						return LiferayFormBuilder.superclass._setFields.apply(instance, arguments);
 					},
 
+					_setParentFields: function(val) {
+						var instance = this;
+						var parentFields = [];
+
+				        A.Array.each(val, function(field, index) {
+				        	parentFields.push(instance.createField(field));
+				        });
+
+				        return new A.ArrayList(parentFields);
+					},
+					
 					_toggleInputDirection: function(locale) {
 						var rtl = Liferay.Language.direction[locale] === 'rtl';
 


### PR DESCRIPTION
@leoadb, we just need to make sure we're not allowing saving duplicate fields name in the structure. When we drag'n'drop a field its name should be random at first to avoid easy collisions with the parent structure. Aren't we doing this already @linolaoj?

Thanks