### PR TITLE
LPS-70740 Revert java fix of LPS-50193: When edit one record in Spreadsheet and current locale is not default locale with old record. We need to add new defaultLocale value for this field. Otherwise, in DDMImpl.mergeFields(), the array newFieldsDisplayValues is empty. mergedLocaleValues is null so that edit value can't be saved and field value of new version record is null.

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordLocalServiceImpl.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordLocalServiceImpl.java
@@ -234,7 +234,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 		Fields fields = toFields(
 			ddmStructure.getStructureId(), fieldsMap,
-			serviceContext.getLocale(), LocaleUtil.getSiteDefault(), true);
+			serviceContext.getLocale(), LocaleUtil.getSiteDefault());
 
 		return ddlRecordLocalService.addRecord(
 			userId, groupId, recordSetId, displayIndex, fields, serviceContext);
@@ -996,8 +996,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 		Fields fields = toFields(
 			ddmStructure.getStructureId(), fieldsMap,
-			serviceContext.getLocale(), oldDDMFormValues.getDefaultLocale(),
-			false);
+			serviceContext.getLocale(), oldDDMFormValues.getDefaultLocale());
 
 		return ddlRecordLocalService.updateRecord(
 			userId, recordId, false, displayIndex, fields, mergeFields,
@@ -1267,7 +1266,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	protected Fields toFields(
 		long ddmStructureId, Map<String, Serializable> fieldsMap, Locale locale,
-		Locale defaultLocale, boolean create) {
+		Locale defaultLocale) {
 
 		Fields fields = new Fields();
 
@@ -1278,7 +1277,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 			field.setName(entry.getKey());
 			field.addValue(locale, String.valueOf(entry.getValue()));
 
-			if (create && !locale.equals(defaultLocale)) {
+			if (!locale.equals(defaultLocale)) {
 				field.addValue(defaultLocale, String.valueOf(entry.getValue()));
 			}
 


### PR DESCRIPTION
@leoadb, could you please add tests for this fix? Fields and fields merge operation is usually very fragile.

Thanks