### PR TITLE
[TS] LPS-95606

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -3220,32 +3220,7 @@ AUI.add(
 									return;
 								}
 
-								var currentLocale = field.get('displayLocale');
-								var originalField = field.originalField;
-
-								var newFieldLocalizations = field.get('localizationMap');
-								var totalLocalizations = originalField.get('localizationMap');
-
-								for (var localization in totalLocalizations) {
-									if (localization === currentLocale) {
-										continue;
-									}
-
-									if (!newFieldLocalizations[localization]) {
-										var localizationValue = '';
-
-										if (newFieldLocalizations[defaultLocale]) {
-											localizationValue = newFieldLocalizations[defaultLocale];
-										}
-										else if (defaultLocale === field.get('displayLocale') && field.getValue()) {
-											localizationValue = field.getValue();
-										}
-
-										newFieldLocalizations[localization] = localizationValue;
-									}
-								}
-
-								field.set('localizationMap', newFieldLocalizations);
+								instance.populateBlankLocalizationMap(defaultLocale, field.originalField, field);
 							}
 						);
 					},
@@ -3256,6 +3231,43 @@ AUI.add(
 						var fields = parentField.get('fields');
 
 						fields.splice(newIndex, 0, fields.splice(oldIndex, 1)[0]);
+					},
+
+					populateBlankLocalizationMap(defaultLocale, originalField, repeatedField) {
+						var instance = this;
+
+						var newFieldLocalizations = repeatedField.get('localizationMap');
+						var totalLocalizations = originalField.get('localizationMap');
+
+						var currentLocale = repeatedField.get('displayLocale');
+
+						for (var localization in totalLocalizations) {
+							if (localization === currentLocale) {
+								continue;
+							}
+
+							if (!newFieldLocalizations[localization]) {
+								var localizationValue = '';
+
+								if (newFieldLocalizations[defaultLocale]) {
+									localizationValue = newFieldLocalizations[defaultLocale];
+								}
+								else if (defaultLocale === repeatedField.get('displayLocale') && repeatedField.getValue()) {
+									localizationValue = repeatedField.getValue();
+								}
+
+								newFieldLocalizations[localization] = localizationValue;
+							}
+						}
+
+						repeatedField.set('localizationMap', newFieldLocalizations);
+
+						var newNestedFields = repeatedField.get('fields');
+						var originalNestedFields = originalField.get('fields');
+
+						for (var i = 0; i < newNestedFields.length; i++) {
+							instance.populateBlankLocalizationMap(defaultLocale, originalNestedFields[i], newNestedFields[i]);
+						}
 					},
 
 					registerRepeatable: function(field) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -3228,7 +3228,7 @@ AUI.add(
 
 								for (var localization in totalLocalizations) {
 									if (localization === currentLocale) {
-										return;
+										continue;
 									}
 
 									if (!newFieldLocalizations[localization]) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-33858
https://issues.liferay.com/browse/LPS-95606

From @Alec-Shay:

> Previously, [LPS-90724](https://issues.liferay.com/browse/LPS-90724) fixed an issue in which, if repeatable fields do not have values filled in for all (relevant) translations, then the values will be mixed up and updated incorrectly (this is because when they are processed in the Java later on, it has less values than it needs, and it can no longer distinguish the correct order, or match them to the proper fields if out of order). It fixed that by forcing any missing translations to be populated by copying the default translation once the content is published.
> 
> That fix did not properly address nested fields though, as nested fields are added with the repeated field all at once with a template, so the `originalFields` variable can't register them the same way. This fix refactors the code added in LPS-90724 so that it can recursively traverse through each of the nested fields and populate them as well.
> 
> Note that in master, LPS-90724 caused an issue specifically for IE11, [LPS-93851](https://issues.liferay.com/browse/LPS-93851), but the fix for that also ended up removing the functionality from the fix for LPS-90724 because the function would return early from that change. To address that, I also separately added this commit (https://github.com/ChrisKian/liferay-portal/commit/0c12c31af243d96e61613fccdd548864e0396f66), though it would have been fixed by the refactor anyway.
> 
> Please let me know if there are any questions or concerns with this. Thank you.