### PR TITLE
Lps 98527 matt

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -684,6 +684,20 @@ AUI.add(
 					parser.parseContent(content);
 				},
 
+				populateRepeatedSiblings: function(locale) {
+					var instance = this;
+
+					var siblings = instance.getRepeatedSiblings();
+
+					siblings.forEach(function(item) {
+						var localizationMap = item.get('localizationMap');
+
+						if (Lang.isUndefined(localizationMap[locale])) {
+							localizationMap[locale] = '';
+						}
+					});
+				},
+
 				remove: function() {
 					var instance = this;
 
@@ -936,6 +950,8 @@ AUI.add(
 							value !== localizationMap[defaultLocale]
 						) {
 							localizationMap[locale] = value;
+
+							instance.populateRepeatedSiblings(locale);
 						}
 					} else {
 						localizationMap = value;


### PR DESCRIPTION
Notes from @Matthewchan1:

> https://issues.liferay.com/browse/LPS-98527
> 
> Issue:
> Customized fields for web content are becoming "dirtied", meaning they save language translations simply by switching between localizations.
> 
> Cause:
> In [_onLocaleChanged](https://github.com/liferay/liferay-portal/blob/d8129c6aa4b153c4fd7569ee080bf1612c977bb6/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js#L1029), we are immediately adding new localizations to the localizationMap when they are first displayed. I think the problem is that we needed to delay adding localizations until the user manually enters a different value, which is read by [updateLocalizationMap](https://github.com/liferay/liferay-portal/blob/d8129c6aa4b153c4fd7569ee080bf1612c977bb6/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js#L922).
> 
> Fix:
> I just turned addLocaleToLocalizationMap into a getter so that localizations can be created at a later time, and used this getter to display the default translation in the user interface.
> 
> I also gave UpdateLocalizationMap a check to see if localized text no longer matches the default, which means the user has modified it.
> 
> Finally, to handle fields duplicated by the Repeatable setting, I added in an extra function populateRepeatedSiblings.
> 
> After the inclusion of this fix, web content locales will not save translations upon switching and instead follow the default localization until taking in user input.