### PR TITLE
[TS] LPS-100797

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
@@ -23,7 +23,14 @@
 		<div class="input-group-item input-group-item-shrink input-localized-content <%= hideClass %>" role="menu" style="justify-content: flex-end;">
 
 			<%
-			String defaultLanguageId = LocaleUtil.toLanguageId(ddmForm.getDefaultLocale());
+			String defaultLanguageId;
+
+			if (defaultEditLocale == null) {
+				defaultLanguageId = LocaleUtil.toLanguageId(ddmForm.getDefaultLocale());
+			}
+			else {
+				defaultLanguageId = LocaleUtil.toLanguageId(defaultEditLocale);
+			}
 
 			String normalizedDefaultLanguageId = StringUtil.replace(defaultLanguageId, '_', '-');
 			%>
@@ -47,7 +54,14 @@
 
 						uniqueLanguageIds.add(defaultLanguageId);
 
-						Set<Locale> availableLocales = ddmForm.getAvailableLocales();
+						Set<Locale> availableLocales;
+
+						if (defaultEditLocale == null) {
+							availableLocales = ddmForm.getAvailableLocales();
+						}
+						else {
+							availableLocales = LanguageUtil.getAvailableLocales(groupId);
+						}
 
 						for (Locale availableLocale : availableLocales) {
 							String curLanguageId = LocaleUtil.toLanguageId(availableLocale);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-100797

Hi @leoadb ,

Can you help us review this bug fix?

Notes from @wanderlast:

> This fix addresses a regression caused by [LPS-91185](https://issues.liferay.com/browse/LPS-91185) which leads to only the site's default language being shown for localization of the 'content' area even if a different default language is chosen for that specific web content. 
> 
> It essentially prefers the use of the defaultEditLocale, but, if not present (as is the case in LPS-91185), uses the ddmForm's locale instead. Please let me know if you have any questions. 
> 
> Thanks!