### PR TITLE
[TECHNICAL SUPPORT] LPS-100132 The removeDDMValidationExpression should come before any possible return, otherwise the fields are still going to be validated before persisting the entry

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCCommandHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCCommandHelper.java
@@ -61,12 +61,6 @@ public class AddFormInstanceRecordMVCCommandHelper {
 			DDMFormValues ddmFormValues, Locale locale)
 		throws Exception {
 
-		List<DDMFormField> requiredFields = getRequiredFields(ddmForm);
-
-		if (requiredFields.isEmpty()) {
-			return;
-		}
-
 		DDMFormEvaluatorEvaluateResponse ddmFormEvaluatorEvaluateResponse =
 			evaluate(actionRequest, ddmForm, ddmFormValues, locale);
 
@@ -78,12 +72,18 @@ public class AddFormInstanceRecordMVCCommandHelper {
 
 		invisibleFields.addAll(fieldsFromDisabledPages);
 
-		if (invisibleFields.isEmpty()) {
+		removeDDMValidationExpression(
+			ddmForm.getDDMFormFields(), invisibleFields);
+
+		List<DDMFormField> requiredFields = getRequiredFields(ddmForm);
+
+		if (requiredFields.isEmpty()) {
 			return;
 		}
 
-		removeDDMValidationExpression(
-			ddmForm.getDDMFormFields(), invisibleFields);
+		if (invisibleFields.isEmpty()) {
+			return;
+		}
 
 		removeRequiredProperty(invisibleFields, requiredFields);
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCCommandHelperTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCCommandHelperTest.java
@@ -77,6 +77,8 @@ public class AddFormInstanceRecordMVCCommandHelperTest extends PowerMockito {
 		setUpAddRecordMVCCommandHelper();
 		setUpLanguageUtil();
 		setUpResourceBundleUtil();
+
+		mockGetDDMFormLayout();
 	}
 
 	@Test
@@ -119,8 +121,6 @@ public class AddFormInstanceRecordMVCCommandHelperTest extends PowerMockito {
 
 		mockDDMFormEvaluator(changedProperties);
 
-		mockGetDDMFormLayout();
-
 		_addRecordMVCCommandHelper.updateRequiredFieldsAccordingToVisibility(
 			_actionRequest, _ddmForm, _ddmFormValues, LocaleUtil.US);
 
@@ -134,8 +134,6 @@ public class AddFormInstanceRecordMVCCommandHelperTest extends PowerMockito {
 		changedProperties.put("visible", true);
 
 		mockDDMFormEvaluator(changedProperties);
-
-		mockGetDDMFormLayout();
 
 		_addRecordMVCCommandHelper.updateRequiredFieldsAccordingToVisibility(
 			_actionRequest, _ddmForm, _ddmFormValues, LocaleUtil.US);


### PR DESCRIPTION
Relevant tickets:
https://issues.liferay.com/browse/LPS-100132