### PR TITLE
[TECHNICAL SUPPORT] LPS-106352

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/query/contributor/DLFileEntryModelPreFilterContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/query/contributor/DLFileEntryModelPreFilterContributor.java
@@ -143,10 +143,25 @@ public class DLFileEntryModelPreFilterContributor
 
 				BooleanQuery booleanQuery = new BooleanQueryImpl();
 
-				booleanQuery.addRequiredTerm(
-					ddmStructureFieldName,
-					StringPool.QUOTE + ddmStructureFieldValue +
-						StringPool.QUOTE);
+				if (ddmStructureFieldValue instanceof String[]) {
+					String[] ddmStructureFieldValueArray =
+						(String[])ddmStructureFieldValue;
+
+					for (String ddmStructureFieldValueString :
+							ddmStructureFieldValueArray) {
+
+						booleanQuery.addRequiredTerm(
+							ddmStructureFieldName,
+							StringPool.QUOTE + ddmStructureFieldValueString +
+								StringPool.QUOTE);
+					}
+				}
+				else {
+					booleanQuery.addRequiredTerm(
+						ddmStructureFieldName,
+						StringPool.QUOTE + ddmStructureFieldValue +
+							StringPool.QUOTE);
+				}
 
 				booleanFilter.add(
 					new QueryFilter(booleanQuery), BooleanClauseOccur.MUST);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMImpl.java
@@ -357,7 +357,8 @@ public class DDMImpl implements DDM {
 
 			String[] stringArray = ArrayUtil.toStringArray(jsonArray);
 
-			fieldValue = stringArray[0];
+			fieldValue = StringUtil.merge(
+				stringArray, StringPool.COMMA_AND_SPACE);
 		}
 
 		return fieldValue;
@@ -486,7 +487,12 @@ public class DDMImpl implements DDM {
 
 			String[] stringArray = ArrayUtil.toStringArray(jsonArray);
 
-			fieldValue = stringArray[0];
+			if (stringArray.length > 1) {
+				fieldValue = stringArray;
+			}
+			else {
+				fieldValue = stringArray[0];
+			}
 		}
 
 		return fieldValue;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -139,9 +139,24 @@ public class DDMIndexerImpl implements DDMIndexer {
 				ddmStructureFieldValue, structure.getFieldType(fieldName));
 		}
 
-		booleanQuery.addRequiredTerm(
-			ddmStructureFieldName,
-			StringPool.QUOTE + ddmStructureFieldValue + StringPool.QUOTE);
+		if (ddmStructureFieldValue instanceof String[]) {
+			String[] ddmStructureFieldValueArray =
+				(String[])ddmStructureFieldValue;
+
+			for (String ddmStructureFieldValueString :
+					ddmStructureFieldValueArray) {
+
+				booleanQuery.addRequiredTerm(
+					ddmStructureFieldName,
+					StringPool.QUOTE + ddmStructureFieldValueString +
+						StringPool.QUOTE);
+			}
+		}
+		else {
+			booleanQuery.addRequiredTerm(
+				ddmStructureFieldName,
+				StringPool.QUOTE + ddmStructureFieldValue + StringPool.QUOTE);
+		}
 
 		return new QueryFilter(booleanQuery);
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-106352

Asset Publisher filter by field doesn't work with multiple selection fields, because only first element is used.

I am returning a String[] in case select field has more than one selected element and adding one query term for each array element.

/cc: @dacousalr @ealonso @adolfopa