### PR TITLE
LPS-106834 change class for required mark on ddm from reference-mark to text-warning

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -83,7 +83,7 @@ AUI.add(
 			'<div class="lfr-ddm-repeatable-helper"></div>';
 
 		var TPL_REQUIRED_MARK =
-			'<span class="text-warning">' +
+			'<span class="reference-mark">' +
 			Liferay.Util.getLexiconIconTpl('asterisk') +
 			'<span class="hide-accessible">' +
 			Liferay.Language.get('required') +


### PR DESCRIPTION
Hi!
I assigned this review to you because I think Forms team is the responsible of DDM now.
I talked with the team Frontend Infrastructure and as a result, I think that only change class for the required mark on ddm_form.js from reference-mark to text-warning is needed.
I think that this change do not have other implications, but I am not sure of it.

Thanks for the help.