### PR TITLE
LPS-110810 dynamic-data-mapping-web: Reintroduce double call

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -4070,6 +4070,12 @@ AUI.add(
 					}
 				},
 
+				_onSubmitForm() {
+					var instance = this;
+
+					instance.updateDDMFormInputValue();
+				},
+
 				_valueFormNode() {
 					var instance = this;
 
@@ -4139,6 +4145,11 @@ AUI.add(
 
 						if (instance.get('synchronousFormSubmission')) {
 							instance.eventHandlers.push(
+								formNode.on(
+									'submit',
+									instance._onSubmitForm,
+									instance
+								),
 								Liferay.on(
 									'submitForm',
 									instance._onLiferaySubmitForm,


### PR DESCRIPTION
+ duplication necessary LRQA-57079 and LPS-109545 still works

https://issues.liferay.com/browse/LPS-110810

I don't know why the duplicate call is necessary, but for some reason a DDL with a boolean WITHOUT a label will not call _onLiferaySubmitForm; only calls _onSubmitForm.  