### PR TITLE
LPS-112800 Dynamic Data List form default language

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record.jsp
@@ -21,6 +21,8 @@ String redirect = ParamUtil.getString(request, "redirect");
 
 String portletResource = ParamUtil.getString(request, "portletResource");
 
+User userDisplay = themeDisplay.getUser();
+
 DDLRecord record = (DDLRecord)request.getAttribute(DDLWebKeys.DYNAMIC_DATA_LISTS_RECORD);
 
 long recordId = BeanParamUtil.getLong(record, request, "recordId");
@@ -55,6 +57,15 @@ else if (Validator.isNull(defaultLanguageId)) {
 }
 
 String languageId = ParamUtil.getString(request, "languageId", defaultLanguageId);
+
+Locale defaultEditLocale = LocaleUtil.fromLanguageId(ddmStructure.getDefaultLanguageId());
+
+if (Arrays.asList(ddmStructure.getAvailableLanguageIds()).contains(themeDisplay.getLanguageId())) {
+	defaultEditLocale = themeDisplay.getLocale();
+}
+else if (Arrays.asList(ddmStructure.getAvailableLanguageIds()).contains(userDisplay.getLanguageId())) {
+	defaultEditLocale = userDisplay.getLocale();
+}
 
 boolean translating = false;
 
@@ -193,11 +204,12 @@ else {
 							classNameId="<%= classNameId %>"
 							classPK="<%= classPK %>"
 							ddmFormValues="<%= ddmFormValues %>"
-							defaultEditLocale="<%= LocaleUtil.fromLanguageId(themeDisplay.getLanguageId()) %>"
+							defaultEditLocale="<%= defaultEditLocale %>"
 							defaultLocale="<%= LocaleUtil.fromLanguageId(defaultLanguageId) %>"
 							groupId="<%= recordSet.getGroupId() %>"
 							repeatable="<%= translating ? false : true %>"
 							requestedLocale="<%= locale %>"
+							showLanguageSelector="<%= false %>"
 						/>
 					</c:when>
 					<c:otherwise>
@@ -207,7 +219,7 @@ else {
 									classNameId="<%= classNameId %>"
 									classPK="<%= classPK %>"
 									ddmFormValues="<%= ddmFormValues %>"
-									defaultEditLocale="<%= LocaleUtil.fromLanguageId(defaultLanguageId) %>"
+									defaultEditLocale="<%= defaultEditLocale %>"
 									defaultLocale="<%= LocaleUtil.fromLanguageId(defaultLanguageId) %>"
 									groupId="<%= recordSet.getGroupId() %>"
 									repeatable="<%= translating ? false : true %>"

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/init.jsp
@@ -114,7 +114,9 @@ page import="com.liferay.taglib.search.ResultRow" %>
 <%@ page import="java.text.Format" %>
 
 <%@ page import="java.util.ArrayList" %><%@
+page import="java.util.Arrays" %><%@
 page import="java.util.List" %><%@
+page import="java.util.Locale" %><%@
 page import="java.util.Map" %><%@
 page import="java.util.Objects" %>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping Taglib
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.taglib
-Bundle-Version: 5.0.4
+Bundle-Version: 5.1.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.taglib.servlet.taglib,\
 	com.liferay.dynamic.data.mapping.taglib.servlet.taglib.base

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/liferay-ddm.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/liferay-ddm.xml
@@ -97,6 +97,12 @@
 				<defaultValue>true</defaultValue>
 			</attribute>
 			<attribute>
+				<name>showLanguageSelector</name>
+				<inputType>boolean</inputType>
+				<outputType>boolean</outputType>
+				<defaultValue>true</defaultValue>
+			</attribute>
+			<attribute>
 				<name>synchronousFormSubmission</name>
 				<inputType>boolean</inputType>
 				<outputType>boolean</outputType>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/java/com/liferay/dynamic/data/mapping/taglib/servlet/taglib/base/BaseHTMLTag.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/java/com/liferay/dynamic/data/mapping/taglib/servlet/taglib/base/BaseHTMLTag.java
@@ -97,6 +97,10 @@ public abstract class BaseHTMLTag extends com.liferay.taglib.util.IncludeTag {
 		return _showEmptyFieldLabel;
 	}
 
+	public boolean getShowLanguageSelector() {
+		return _showLanguageSelector;
+	}
+
 	public boolean getSynchronousFormSubmission() {
 		return _synchronousFormSubmission;
 	}
@@ -165,6 +169,10 @@ public abstract class BaseHTMLTag extends com.liferay.taglib.util.IncludeTag {
 		_showEmptyFieldLabel = showEmptyFieldLabel;
 	}
 
+	public void setShowLanguageSelector(boolean showLanguageSelector) {
+		_showLanguageSelector = showLanguageSelector;
+	}
+
 	public void setSynchronousFormSubmission(boolean synchronousFormSubmission) {
 		_synchronousFormSubmission = synchronousFormSubmission;
 	}
@@ -196,6 +204,7 @@ public abstract class BaseHTMLTag extends com.liferay.taglib.util.IncludeTag {
 		_repeatable = true;
 		_requestedLocale = null;
 		_showEmptyFieldLabel = true;
+		_showLanguageSelector = true;
 		_synchronousFormSubmission = true;
 	}
 
@@ -222,6 +231,7 @@ public abstract class BaseHTMLTag extends com.liferay.taglib.util.IncludeTag {
 		setNamespacedAttribute(request, "repeatable", _repeatable);
 		setNamespacedAttribute(request, "requestedLocale", _requestedLocale);
 		setNamespacedAttribute(request, "showEmptyFieldLabel", _showEmptyFieldLabel);
+		setNamespacedAttribute(request, "showLanguageSelector", _showLanguageSelector);
 		setNamespacedAttribute(request, "synchronousFormSubmission", _synchronousFormSubmission);
 	}
 
@@ -246,6 +256,7 @@ public abstract class BaseHTMLTag extends com.liferay.taglib.util.IncludeTag {
 	private boolean _repeatable = true;
 	private java.util.Locale _requestedLocale = null;
 	private boolean _showEmptyFieldLabel = true;
+	private boolean _showLanguageSelector = true;
 	private boolean _synchronousFormSubmission = true;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/init.jsp
@@ -35,6 +35,7 @@ boolean readOnly = GetterUtil.getBoolean(String.valueOf(request.getAttribute("li
 boolean repeatable = GetterUtil.getBoolean(String.valueOf(request.getAttribute("liferay-ddm:html:repeatable")), true);
 java.util.Locale requestedLocale = (java.util.Locale)request.getAttribute("liferay-ddm:html:requestedLocale");
 boolean showEmptyFieldLabel = GetterUtil.getBoolean(String.valueOf(request.getAttribute("liferay-ddm:html:showEmptyFieldLabel")), true);
+boolean showLanguageSelector = GetterUtil.getBoolean(String.valueOf(request.getAttribute("liferay-ddm:html:showLanguageSelector")), true);
 boolean synchronousFormSubmission = GetterUtil.getBoolean(String.valueOf(request.getAttribute("liferay-ddm:html:synchronousFormSubmission")), true);
 Map<String, Object> dynamicAttributes = (Map<String, Object>)request.getAttribute("liferay-ddm:html:dynamicAttributes");
 %>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
@@ -91,18 +91,20 @@
 							).build();
 							%>
 
-							<liferay-ui:icon
-								alt="<%= title %>"
-								data="<%= iconData %>"
-								icon="<%= StringUtil.toLowerCase(StringUtil.replace(curLanguageId, '_', '-')) %>"
-								iconCssClass="inline-item inline-item-before"
-								linkCssClass="<%= linkCssClass %>"
-								markupView="lexicon"
-								message="<%= StringUtil.replace(curLanguageId, '_', '-') %>"
-								onClick="event.preventDefault(); fireLocaleChanged(event);"
-								url="javascript:;"
-							>
-							</liferay-ui:icon>
+							<c:if test="<%= showLanguageSelector %>">
+								<liferay-ui:icon
+									alt="<%= title %>"
+									data="<%= iconData %>"
+									icon="<%= StringUtil.toLowerCase(StringUtil.replace(curLanguageId, '_', '-')) %>"
+									iconCssClass="inline-item inline-item-before"
+									linkCssClass="<%= linkCssClass %>"
+									markupView="lexicon"
+									message="<%= StringUtil.replace(curLanguageId, '_', '-') %>"
+									onClick="event.preventDefault(); fireLocaleChanged(event);"
+									url="javascript:;"
+								>
+								</liferay-ui:icon>
+							</c:if>
 
 						<%
 						}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/liferay-ddm.tld
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/liferay-ddm.tld
@@ -102,6 +102,12 @@
 			<type>boolean</type>
 		</attribute>
 		<attribute>
+			<name>showLanguageSelector</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>boolean</type>
+		</attribute>
+		<attribute>
 			<name>synchronousFormSubmission</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/com/liferay/dynamic/data/mapping/taglib/servlet/taglib/base/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/com/liferay/dynamic/data/mapping/taglib/servlet/taglib/base/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/com/liferay/dynamic/data/mapping/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/com/liferay/dynamic/data/mapping/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -358,17 +358,7 @@ AUI.add(
 				if (instance.get('readOnly')) {
 					retVal = true;
 				}
-				else {
-					var form = instance.getForm();
-
-					if (
-						!instance.get('localizable') &&
-						form.getDefaultLocale() != instance.get('displayLocale')
-					) {
-						retVal = true;
-					}
-				}
-
+				
 				return retVal;
 			},
 		};
@@ -4178,11 +4168,15 @@ AUI.add(
 				},
 
 				fillEmptyLocales(instance, fields, availableLanguageIds) {
+					var defaultLocale = instance.getDefaultLocale();
+
+					if (availableLanguageIds.indexOf(defaultLocale) === -1){
+						availableLanguageIds.push(defaultLocale);
+					}
+
 					fields.forEach((field) => {
 						if (field.get('localizable')) {
 							var localizationMap = field.get('localizationMap');
-
-							var defaultLocale = field.getDefaultLocale();
 
 							availableLanguageIds.forEach((locale) => {
 								if (!localizationMap[locale]) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -358,7 +358,7 @@ AUI.add(
 				if (instance.get('readOnly')) {
 					retVal = true;
 				}
-				
+
 				return retVal;
 			},
 		};
@@ -4170,7 +4170,7 @@ AUI.add(
 				fillEmptyLocales(instance, fields, availableLanguageIds) {
 					var defaultLocale = instance.getDefaultLocale();
 
-					if (availableLanguageIds.indexOf(defaultLocale) === -1){
+					if (availableLanguageIds.indexOf(defaultLocale) === -1) {
 						availableLanguageIds.push(defaultLocale);
 					}
 


### PR DESCRIPTION
Hi @leoadb.
Could you please review this pull request?
The related LPPs: LPP-37226, LPP-37245.
I removed the language selector from DDL Display Portlet and the editing language to render the form respecting the following order: Request, User, Site.

The current structure of the DDL can't store the state of the form, so when you use the "Language selector portlet" the page the page will reload and the content of the form will be deleted.

Thank you and best regards,
Marci