### PR TITLE
LPS-113510 | Repeated fields are shown blank in web content if default language and user's language are different from structure's default language

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
@@ -224,7 +224,7 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 		DDMFormFieldOptions ddmFormFieldOptions =
 			ddmFormField.getDDMFormFieldOptions();
 
-		Locale structureLocale = _getStructureLocale(
+		Locale favoredLocale = _getFavoredLocale(
 			httpServletRequest, ddmFormField, locale);
 
 		for (String value : ddmFormFieldOptions.getOptionsValues()) {
@@ -237,7 +237,7 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 			addDDMFormFieldOptionHTML(
 				httpServletRequest, httpServletResponse, ddmFormField, mode,
 				readOnly, freeMarkerContext, sb,
-				label.getString(structureLocale), value);
+				label.getString(favoredLocale), value);
 		}
 
 		return sb.toString();
@@ -260,7 +260,7 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 			return fieldContext;
 		}
 
-		Locale structureLocale = _getStructureLocale(
+		Locale structureLocale = _getFavoredLocale(
 			httpServletRequest, ddmFormField, locale);
 
 		fieldContext = new HashMap<>();
@@ -696,7 +696,7 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 		return writer.toString();
 	}
 
-	private Locale _getStructureLocale(
+	private Locale _getFavoredLocale(
 		HttpServletRequest httpServletRequest, DDMFormField ddmFormField,
 		Locale locale) {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
@@ -67,6 +67,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -260,10 +261,30 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 
 		Set<Locale> availableLocales = ddmForm.getAvailableLocales();
 
-		Locale structureLocale = locale;
+		Locale structureLocale;
 
-		if (!availableLocales.contains(locale)) {
-			structureLocale = ddmForm.getDefaultLocale();
+		Locale ddmFormDefaultLocale = ddmForm.getDefaultLocale();
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Locale siteDefaultLocale = themeDisplay.getSiteDefaultLocale();
+
+		if (availableLocales.contains(locale)) {
+			structureLocale = locale;
+		}
+		else if (availableLocales.contains(ddmFormDefaultLocale)) {
+			structureLocale = ddmFormDefaultLocale;
+		}
+		else if (availableLocales.contains(siteDefaultLocale)) {
+			structureLocale = siteDefaultLocale;
+		}
+		else {
+			Stream<Locale> stream = availableLocales.stream();
+
+			structureLocale = stream.findFirst(
+			).get();
 		}
 
 		fieldContext = new HashMap<>();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
@@ -224,35 +224,8 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 		DDMFormFieldOptions ddmFormFieldOptions =
 			ddmFormField.getDDMFormFieldOptions();
 
-		DDMForm ddmForm = ddmFormField.getDDMForm();
-
-		Set<Locale> availableLocales = ddmForm.getAvailableLocales();
-
-		Locale structureLocale;
-
-		Locale ddmFormDefaultLocale = ddmForm.getDefaultLocale();
-
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		Locale siteDefaultLocale = themeDisplay.getSiteDefaultLocale();
-
-		if (availableLocales.contains(locale)) {
-			structureLocale = locale;
-		}
-		else if (availableLocales.contains(ddmFormDefaultLocale)) {
-			structureLocale = ddmFormDefaultLocale;
-		}
-		else if (availableLocales.contains(siteDefaultLocale)) {
-			structureLocale = siteDefaultLocale;
-		}
-		else {
-			Stream<Locale> stream = availableLocales.stream();
-
-			structureLocale = stream.findFirst(
-			).get();
-		}
+		Locale structureLocale = _getStructureLocale(
+			httpServletRequest, ddmFormField, locale);
 
 		for (String value : ddmFormFieldOptions.getOptionsValues()) {
 			if (value.equals(StringPool.BLANK)) {
@@ -287,35 +260,8 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 			return fieldContext;
 		}
 
-		DDMForm ddmForm = ddmFormField.getDDMForm();
-
-		Set<Locale> availableLocales = ddmForm.getAvailableLocales();
-
-		Locale structureLocale;
-
-		Locale ddmFormDefaultLocale = ddmForm.getDefaultLocale();
-
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		Locale siteDefaultLocale = themeDisplay.getSiteDefaultLocale();
-
-		if (availableLocales.contains(locale)) {
-			structureLocale = locale;
-		}
-		else if (availableLocales.contains(ddmFormDefaultLocale)) {
-			structureLocale = ddmFormDefaultLocale;
-		}
-		else if (availableLocales.contains(siteDefaultLocale)) {
-			structureLocale = siteDefaultLocale;
-		}
-		else {
-			Stream<Locale> stream = availableLocales.stream();
-
-			structureLocale = stream.findFirst(
-			).get();
-		}
+		Locale structureLocale = _getStructureLocale(
+			httpServletRequest, ddmFormField, locale);
 
 		fieldContext = new HashMap<>();
 
@@ -748,6 +694,43 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 		template.processTemplate(writer);
 
 		return writer.toString();
+	}
+
+	private Locale _getStructureLocale(
+		HttpServletRequest httpServletRequest, DDMFormField ddmFormField,
+		Locale locale) {
+
+		DDMForm ddmForm = ddmFormField.getDDMForm();
+
+		Set<Locale> availableLocales = ddmForm.getAvailableLocales();
+
+		Locale structureLocale;
+
+		Locale ddmFormDefaultLocale = ddmForm.getDefaultLocale();
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Locale siteDefaultLocale = themeDisplay.getSiteDefaultLocale();
+
+		if (availableLocales.contains(locale)) {
+			structureLocale = locale;
+		}
+		else if (availableLocales.contains(ddmFormDefaultLocale)) {
+			structureLocale = ddmFormDefaultLocale;
+		}
+		else if (availableLocales.contains(siteDefaultLocale)) {
+			structureLocale = siteDefaultLocale;
+		}
+		else {
+			Stream<Locale> stream = availableLocales.stream();
+
+			structureLocale = stream.findFirst(
+			).get();
+		}
+
+		return structureLocale;
 	}
 
 	private static final String _DEFAULT_NAMESPACE = "alloy";

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
@@ -704,9 +704,15 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 
 		Set<Locale> availableLocales = ddmForm.getAvailableLocales();
 
-		Locale structureLocale;
+		if (availableLocales.contains(locale)) {
+			return locale;
+		}
 
 		Locale ddmFormDefaultLocale = ddmForm.getDefaultLocale();
+
+		if (availableLocales.contains(ddmFormDefaultLocale)) {
+			return ddmFormDefaultLocale;
+		}
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
@@ -714,23 +720,14 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 
 		Locale siteDefaultLocale = themeDisplay.getSiteDefaultLocale();
 
-		if (availableLocales.contains(locale)) {
-			structureLocale = locale;
-		}
-		else if (availableLocales.contains(ddmFormDefaultLocale)) {
-			structureLocale = ddmFormDefaultLocale;
-		}
-		else if (availableLocales.contains(siteDefaultLocale)) {
-			structureLocale = siteDefaultLocale;
-		}
-		else {
-			Stream<Locale> stream = availableLocales.stream();
-
-			structureLocale = stream.findFirst(
-			).get();
+		if (availableLocales.contains(siteDefaultLocale)) {
+			return siteDefaultLocale;
 		}
 
-		return structureLocale;
+		Stream<Locale> stream = availableLocales.stream();
+
+		return stream.findFirst(
+		).get();
 	}
 
 	private static final String _DEFAULT_NAMESPACE = "alloy";

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
@@ -224,6 +224,36 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 		DDMFormFieldOptions ddmFormFieldOptions =
 			ddmFormField.getDDMFormFieldOptions();
 
+		DDMForm ddmForm = ddmFormField.getDDMForm();
+
+		Set<Locale> availableLocales = ddmForm.getAvailableLocales();
+
+		Locale structureLocale;
+
+		Locale ddmFormDefaultLocale = ddmForm.getDefaultLocale();
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Locale siteDefaultLocale = themeDisplay.getSiteDefaultLocale();
+
+		if (availableLocales.contains(locale)) {
+			structureLocale = locale;
+		}
+		else if (availableLocales.contains(ddmFormDefaultLocale)) {
+			structureLocale = ddmFormDefaultLocale;
+		}
+		else if (availableLocales.contains(siteDefaultLocale)) {
+			structureLocale = siteDefaultLocale;
+		}
+		else {
+			Stream<Locale> stream = availableLocales.stream();
+
+			structureLocale = stream.findFirst(
+			).get();
+		}
+
 		for (String value : ddmFormFieldOptions.getOptionsValues()) {
 			if (value.equals(StringPool.BLANK)) {
 				continue;
@@ -233,8 +263,8 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 
 			addDDMFormFieldOptionHTML(
 				httpServletRequest, httpServletResponse, ddmFormField, mode,
-				readOnly, freeMarkerContext, sb, label.getString(locale),
-				value);
+				readOnly, freeMarkerContext, sb,
+				label.getString(structureLocale), value);
 		}
 
 		return sb.toString();


### PR DESCRIPTION
Hi @leoadb, 

First of all, let me know if I should have sent this pr to another person (/cc @dsanz). 

This solution tries to fix a corner case for repeatable fields of type Selection when the current language (obtained from `themeDisplay`), the structure default language and the web content default language don't match. 

The idea is to make sure that the locale we use to get information to display is one of the available ones. 

Please let me know if you have any questions. Thanks!