### PR TITLE
[TS] LPS-114562

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -230,7 +230,7 @@ AUI.add(
 				};
 
 				var templateResourceURL = Liferay.Util.PortletURL.createResourceURL(
-					themeDisplay.getURLControlPanel(),
+					themeDisplay.getLayoutURL(),
 					templateResourceParameters
 				);
 


### PR DESCRIPTION
From @kevhlee:

> Relevant Tickets:
> <https://issues.liferay.com/browse/LPS-114562>
> 
> The error in the logs was coming from `SecurityPortletContainerWrapper.check()`, which checks if a layout has access to a given portlet (see [here](https://github.com/kevhlee/liferay-portal/blob/LPS-114562/portal-impl/src/com/liferay/portlet/SecurityPortletContainerWrapper.java#L224-L251)). The creation of the repeating text field should have been permitted by the portlet authentication token, however the wrong session authentication token was being used by the portal. When searching for the session authentication token, it uses the layout's plid and the portlet's id and constructs a key out of them to find the session authentication token. All of this can be seen [here](https://github.com/kevhlee/liferay-portal/blob/LPS-114562/portal-impl/src/com/liferay/portal/security/auth/SessionAuthToken.java#L191-L226). The issue was that the layout's plid was incorrect, meaning the wrong layout was being used to authenticate. Thus, in `ddm_form.js`, I changed the URL used in `_getTemplateResourceURL()` so that the correct layout is used in `SecurityPortletContainerWrapper.check()`. 

CC @wanderlast 