### PR TITLE
LPS-117568 Update DDMTemplate.templateKey entries that are null

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
@@ -29,7 +29,7 @@ Import-Package:\
 	org.tukaani.*;resolution:=optional,\
 	\
 	*
-Liferay-Require-SchemaVersion: 3.7.3
+Liferay-Require-SchemaVersion: 3.7.4
 Liferay-Service: true
 Provide-Capability:\
 	liferay.resource.bundle;\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
@@ -296,8 +296,10 @@ public class DDMServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register("3.2.5", "3.2.6", new DummyUpgradeStep());
 
+		registry.register("3.2.6", "3.2.7", new DummyUpgradeStep());
+
 		registry.register(
-			"3.2.6", "3.3.0",
+			"3.2.7", "3.3.0",
 			new UpgradeCTModel(
 				"DDMStructure", "DDMStructureVersion", "DDMTemplate",
 				"DDMTemplateVersion"));
@@ -337,6 +339,11 @@ public class DDMServiceUpgrade implements UpgradeStepRegistrator {
 			new com.liferay.dynamic.data.mapping.internal.upgrade.v3_7_3.
 				UpgradeDDMFormInstanceReport(
 					ddmFormJSONDeserializer, _jsonFactory));
+
+		registry.register(
+			"3.7.3", "3.7.4",
+			new com.liferay.dynamic.data.mapping.internal.upgrade.v3_7_4.
+				UpgradeNullDDMTemplateKeys());
 	}
 
 	@Activate

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_7_4/UpgradeNullDDMTemplateKeys.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_7_4/UpgradeNullDDMTemplateKeys.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v3_7_4;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Jorge Díaz
+ */
+public class UpgradeNullDDMTemplateKeys extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		runSQL(
+			"update DDMTemplate set templateKey = " +
+				"CONCAT(CAST_TEXT(templateId), '_key') where templateKey IS " +
+					"NULL");
+	}
+
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-117568

Fixes some null DDMTemplate.templateKey entries that cause troubles during IX_E6DFAB84 creation for oracle database.
The issue is only reproduce in case you upgrade from 6.1 and you were using DDL list templates.

I am adding the upgrade to master just in case we have more customers with same issue but they didn't noticed that IX_E6DFAB84 wasn't created. For more information see https://issues.liferay.com/browse/PTR-1846

/cc: @achaparro